### PR TITLE
Expose users home as furnace won't use portals

### DIFF
--- a/org.tildearrow.furnace.yml
+++ b/org.tildearrow.furnace.yml
@@ -14,6 +14,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=home
 
 modules:
   - name: rtmidi


### PR DESCRIPTION
Currently furnace will allow the user to save and reload their project however on following runs of furnace these files will disappear.

https://github.com/tildearrow/furnace/issues/2096